### PR TITLE
Pull Request for fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,11 +1,11 @@
 {
 	"schemaVersion": 1,
 	"id": "fullscreenfix",
-	"version": "${version}",
+	"version": "2.2.1",
 	"name": "Borderless Fullscreen",
-	"description": "Borderless Fullscreen",
+	"description": "This mod changes Minecraft's fullscreen mode and makes it more customizable. By default, it makes the game not minimize on lost focus, and allows other windows on top of the game.",
 	"authors": [
-		"Me!"
+		"Bestsoft100"
 	],
 	"contact": {
 		"homepage": "https://github.com/Bestsoft101/Better-Fullscreen",


### PR DESCRIPTION
Pull Request for fabric.mod.json

The mod menu view of the mod will be a little bit more specific when like this.
Right now it looks like this:
<img width="1920" height="1080" alt="2026-01-18_10 09 50" src="https://github.com/user-attachments/assets/d1a443f3-0233-44fb-82b5-3cfcae2c75e2" />

I think I accidentally made the 1.21 one 2.2.1 though